### PR TITLE
fix(cmc): readOffer must use `streams` not `streamIds` on events.get

### DIFF
--- a/components/pryv-cmc/src/index.js
+++ b/components/pryv-cmc/src/index.js
@@ -550,8 +550,12 @@ async function requestScopeUpdate (conn, params) {
 async function readOffer (capabilityUrl, opts) {
   const pryv = (opts && opts.pryv) || require('pryv');
   const cap = new pryv.Connection(capabilityUrl);
+  // `events.get` takes `streams` (recursive read filter), not `streamIds`
+  // (which is the events.create write target). Mirror the field used by
+  // the other events.get callers in this file (listInvites, waitForAccept,
+  // listAcceptedRelationships).
   const events = await cap.apiOne('events.get', {
-    streamIds: [NS_INTERNAL + ':offer'],
+    streams: [NS_INTERNAL + ':offer'],
     limit: 1
   }, 'events');
   if (events.length === 0) {


### PR DESCRIPTION
## Problem

`readOffer` (`components/pryv-cmc/src/index.js:553-556`) calls `events.get` with `{streamIds: [NS_INTERNAL + ':offer'], limit: 1}`. The api-server's `events.get` schema rejects this with:

```
{"id":"invalid-parameters-format",
 "data":[{"code":"OBJECT_ADDITIONAL_PROPERTIES","params":["streamIds"]}]}
```

`events.get` takes `streams` (recursive read filter); `streamIds` is the `events.create` write target. Every `readOffer` call fails against every deploy.

The four other `events.get` callers in this file (`listInvites:374-375`, `waitForAccept:445-446`, `listAcceptedRelationships:827-828`, `acceptScopeUpdate:982`) all already use `streams` correctly — this is an isolated typo.

## Fix

Change `streamIds` → `streams` in `readOffer`. 1-line behavioural change plus a clarifying comment.

## Visible impact pre-fix

Any caller of `cmc.readOffer(capabilityUrl)` throws on the first await. Patient apps can't peek the offer (display title/description/permissions) before clicking accept. HDS's plan-59 Phase-5a UX needs this primitive to render the offer-preview screen.

## Test

No new tests in this PR — the existing `cmc.test.js` suite mocks `Connection.apiOne` and doesn't exercise the wire-shape, so the schema mismatch slipped past unit coverage. The downstream behavior is exercised end-to-end against a deployed open-pryv.io via HDS's `_plans/59-pryv-cmc-integration-atwork/tests/08-sdk-handshake.js` (PASS post-fix).

If you'd like, I can add a contract test that asserts the underlying Connection call uses `streams` — let me know.