### PR TITLE
fix(cmc): readOffer must omit `streams` filter — :_cmc:_internal:offer is not a real parent

### DIFF
--- a/components/pryv-cmc/src/index.js
+++ b/components/pryv-cmc/src/index.js
@@ -550,12 +550,20 @@ async function requestScopeUpdate (conn, params) {
 async function readOffer (capabilityUrl, opts) {
   const pryv = (opts && opts.pryv) || require('pryv');
   const cap = new pryv.Connection(capabilityUrl);
-  // `events.get` takes `streams` (recursive read filter), not `streamIds`
-  // (which is the events.create write target). Mirror the field used by
-  // the other events.get callers in this file (listInvites, waitForAccept,
-  // listAcceptedRelationships).
+  // The capability access has `read` on a single per-capability stream
+  // (`:_cmc:_internal:offer:<capId>`) but the accepter doesn't know
+  // <capId> from the capabilityUrl alone. The parent `:_cmc:_internal:offer`
+  // is NOT a reserved stream that auto-exists on every user account — only
+  // the per-capability children do — so a `streams: [':_cmc:_internal:offer']`
+  // filter resolves to `unknown-referenced-resource`.
+  //
+  // Mirror the plugin's own readOfferViaCapability (acceptOrchestration.ts):
+  // omit the streams filter entirely and rely on the cap access's
+  // permissions to narrow the response to the single offer event this
+  // token can read. The `types` filter is defensive in case the offer
+  // stream ever holds more than one event in future revisions.
   const events = await cap.apiOne('events.get', {
-    streams: [NS_INTERNAL + ':offer'],
+    types: [ET_REQUEST],
     limit: 1
   }, 'events');
   if (events.length === 0) {


### PR DESCRIPTION
Follow-up to #67. After fixing `streamIds → streams`, `cmc.readOffer` still throws against any real api-server:

```
PryvError: events.get >> {"id":"unknown-referenced-resource",
"data":{"streams":[":_cmc:_internal:offer"]}}
```

## Root cause

The api-server validates that streams referenced in `events.get` actually exist on the user's account. `:_cmc:_internal:offer` is **not** auto-provisioned — only the per-capability children `:_cmc:_internal:offer:<capId>` are minted by `capabilityMintHook`. The accepter doesn't know `<capId>` from the `capabilityUrl` alone, so a specific-stream filter isn't possible either.

The plugin's own implementation of the same read — `readOfferViaCapability` in `components/cmc/src/acceptOrchestration.ts:71-78` of open-pryv.io — handles this correctly: **omit the `streams` filter entirely** and rely on the capability access's permissions to narrow the response to the single offer event this token can read.

```ts
// Capability access has `read` on a single per-capability stream
// (:_cmc:_internal:offer:<capId>) but the accepter doesn't know
// <capId> from the capabilityUrl alone. Query events.get without a
// streams filter — the access's permissions limit the response to
// the one event that lives on the only stream this token can read.
// types filter narrows to consent/request-cmc in case the offer stream
// ever holds more than one event in future revisions.
```

## Fix

`readOffer` mirrors that pattern: drop the `streams` filter, keep `types: [ET_REQUEST]` as defense.

## Test

No new tests in this PR — the existing `cmc.test.js` suite mocks `Connection.apiOne`, so neither the field-name bug (PR #67) nor this parent-stream-doesn't-exist bug is caught at unit-test time. Both surface only against a real api-server. The downstream behaviour is exercised end-to-end via HDS plan-59 Phase-3 scenario tests against a deployed open-pryv.io — `cmc.readOffer` returns the offer correctly post-fix.

Happy to add a wire-shape contract test (asserting `events.get` is called with no `streams` field and with `types: ['consent/request-cmc']`) if you'd like it landed alongside the fix.